### PR TITLE
Add support for "base-4.8" and increment the version

### DIFF
--- a/json-stream.cabal
+++ b/json-stream.cabal
@@ -1,5 +1,5 @@
 name:                json-stream
-version:             0.3.0.4
+version:             0.3.1.0
 synopsis:            Incremental applicative JSON parser
 description:         Easy to use JSON parser fully supporting incremental parsing.
                      Parsing grammar in applicative form.
@@ -33,7 +33,7 @@ library
   c-sources:           c_lib/lexer.c
   includes:            c_lib/lexer.h
   include-dirs:        c_lib
-  build-depends:         base >=4.7 && <4.8
+  build-depends:         base >=4.7 && <4.9
                        , bytestring
                        , text
                        , aeson
@@ -51,7 +51,7 @@ test-suite spec
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test, .
   default-language:    Haskell2010
-  build-depends:         base >=4.7 && <4.8
+  build-depends:         base >=4.7 && <4.9
                        , bytestring
                        , text
                        , aeson


### PR DESCRIPTION
Please note that unlike in your preceding releases I've incremented the `x.x.X.x` version, since the dependency changes require that according to PVP.