### PR TITLE
Add conduit flag to expose Data.JsonStream.Conduit.parserConduit

### DIFF
--- a/Data/JsonStream/Conduit.hs
+++ b/Data/JsonStream/Conduit.hs
@@ -1,0 +1,25 @@
+-- |
+-- Module : Data.JsonStream.Conduit
+-- License     : BSD-style
+--
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Use "Data.JsonStream.Parser" parsers in "Data.Conduit".
+
+module Data.JsonStream.Conduit (
+  parserConduit
+) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.Conduit.Internal as C
+
+import           Data.JsonStream.Parser
+
+-- |Use a 'Parser' as a conduit from 'ByteString' input chunks to results, finally returning any parse error or 'Nothing' on success.
+parserConduit :: Parser a -> C.ConduitT ByteString a m (Maybe String)
+parserConduit ps = C.ConduitT (parsePipe $ runParser ps) where
+  parsePipe (ParseYield a p) r = C.HaveOutput (parsePipe p r) a
+  parsePipe (ParseNeedData f) r = C.NeedInput (\i -> parsePipe (f i) r) (\() -> r (Just "Incomplete JSON"))
+  parsePipe (ParseFailed e) r = r (Just e)
+  parsePipe (ParseDone l) r = C.Leftover (r Nothing) l

--- a/json-stream.cabal
+++ b/json-stream.cabal
@@ -28,6 +28,10 @@ source-repository head
   type: git
   location: https://github.com/ondrap/json-stream.git
 
+flag conduit
+  description: Support the conduit package
+  manual: True
+  default: False
 
 library
   exposed-modules:     Data.JsonStream.Parser
@@ -45,6 +49,9 @@ library
                        , vector
                        , unordered-containers
                        , scientific
+  if flag(conduit)
+    exposed-modules:     Data.JsonStream.Conduit
+    build-depends:       conduit
 
   default-language:    Haskell2010
   Ghc-Options:         -Wall -fwarn-incomplete-uni-patterns


### PR DESCRIPTION
This adds a simple conduit converter in a new Data.JsonStream.Conduit module as described in #27.  To avoid adding more dependencies by default this is guarded beind a cabal flag (default off).  This could also be safely enabled by default, or just split off to a separate package (though feels excessive for 5 lines).